### PR TITLE
Fix for memory leak

### DIFF
--- a/event_kafka.conf.xml
+++ b/event_kafka.conf.xml
@@ -3,5 +3,6 @@
 		<param name="bootstrap-servers" value="localhost:9092"/>
 		<param name="topic-prefix" value="topic_name"/>
 		<param name="buffer-size" value="16" /> 
+		<param name="max-retry" value="0" /> 
 	</settings>
  </configuration>

--- a/mod_event_kafka.cpp
+++ b/mod_event_kafka.cpp
@@ -41,6 +41,8 @@
 
 namespace {
 
+    constexpr std::size_t UUID_LENGTH = 36;
+
     template <typename T, std::size_t Muliplier = 1>
     T* malloc_new()
     {
@@ -146,6 +148,10 @@ namespace mod_event_kafka {
         void PublishEvent(switch_event_t *event) {
 
             std::string uuid = std::string(switch_event_get_header(event, "Channel-Call-UUID"));
+
+            if (uuid.length() != UUID_LENGTH)
+                return;
+
             char *event_json = malloc_new<char>();
 
             const switch_status_t json_status = switch_event_serialize_json(event, &event_json);

--- a/mod_event_kafka.cpp
+++ b/mod_event_kafka.cpp
@@ -82,7 +82,6 @@ namespace mod_event_kafka {
 
     class KafkaEventPublisher {
 
-
         public:
         KafkaEventPublisher(){
 
@@ -152,7 +151,6 @@ namespace mod_event_kafka {
             try {
                 uuid = std::string(switch_event_get_header(event, "Channel-Call-UUID"));
             } catch(std::exception &ex) {
-                switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Exception detected in switch_event_get_header() : %s\n", ex.what());
                 return;
             } catch(...) { // Exceptions must not propogate to C caller
                 return;
@@ -173,7 +171,6 @@ namespace mod_event_kafka {
             }
 
             if (_initialized) {
-                switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_INFO, "Invoking send()");
                 const int resp = send(event_json, uuid.c_str(), globals.max_retry);
                 if (resp == -1){
                     switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Failed to produce, with error %s \n", rd_kafka_err2str(rd_kafka_last_error()));
@@ -215,7 +212,6 @@ namespace mod_event_kafka {
 
             if (globals.max_retry == 0 || ++limit <= globals.max_retry)
             {
-                switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_INFO, "Invoking rd_kafka_produce()");
                 const int key_length = key == NULL ? 0 : strlen(key);
                 const int result = rd_kafka_produce(
                     topic,

--- a/mod_event_kafka.cpp
+++ b/mod_event_kafka.cpp
@@ -146,7 +146,7 @@ namespace mod_event_kafka {
         void PublishEvent(switch_event_t *event) {
 
             std::string uuid = std::string(switch_event_get_header(event, "Channel-Call-UUID"));
-            char *event_json = malloc_new<char*>();
+            char *event_json = malloc_new<char>();
             switch_event_serialize_json(event, &event_json);
 
             if(_initialized){
@@ -160,10 +160,8 @@ namespace mod_event_kafka {
                 rd_kafka_poll(producer, 0);
             } else {
                 switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "PublishEvent without active KafkaPublisher\n %s \n", event_json);
+                std::free(event_json);
             }
-
-            std::free(event_json);
-
         }
 
         void Shutdown(){

--- a/mod_event_kafka.cpp
+++ b/mod_event_kafka.cpp
@@ -153,8 +153,9 @@ namespace mod_event_kafka {
                 uuid = std::string(switch_event_get_header(event, "Channel-Call-UUID"));
             } catch(std::exception &ex) {
                 switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Exception detected in switch_event_get_header() : %s\n", ex.what());
+                return;
             } catch(...) { // Exceptions must not propogate to C caller
-
+                return;
             }
 
             if (uuid.length() != UUID_LENGTH)

--- a/mod_event_kafka.cpp
+++ b/mod_event_kafka.cpp
@@ -178,7 +178,7 @@ namespace mod_event_kafka {
 
         int send(char *data, const std::string &key, int limit) {
 
-            if (limit == 0 && ++limit <= globals.max_retry)
+            if (globals.max_retry == 0 || ++limit <= globals.max_retry)
             {
                 const int result = rd_kafka_produce(
                     topic,

--- a/mod_event_kafka.cpp
+++ b/mod_event_kafka.cpp
@@ -230,7 +230,7 @@ namespace mod_event_kafka {
                 const auto last_error = rd_kafka_last_error();
 
                 //not handing other unknown errors
-                if (last_error == RD_KAFKA_RESP_ERR__QUEUE_FULL)
+                if (globals.max_retry != 0 && last_error == RD_KAFKA_RESP_ERR__QUEUE_FULL)
                 {
                     switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG,"queue.buffering.max.messages limit reached, waiting 1sec to flush out.\n");
                     std::thread([this, data, limit, key]() {

--- a/mod_event_kafka.cpp
+++ b/mod_event_kafka.cpp
@@ -147,7 +147,15 @@ namespace mod_event_kafka {
 
         void PublishEvent(switch_event_t *event) {
 
-            std::string uuid = std::string(switch_event_get_header(event, "Channel-Call-UUID"));
+            std::string uuid;
+
+            try {
+                uuid = std::string(switch_event_get_header(event, "Channel-Call-UUID"));
+            } catch(std::exception &ex) {
+                switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Exception detected in switch_event_get_header() : %s\n", ex.what());
+            } catch(...) { // Exceptions must not propogate to C caller
+
+            }
 
             if (uuid.length() != UUID_LENGTH)
                 return;

--- a/mod_event_kafka.hpp
+++ b/mod_event_kafka.hpp
@@ -1,7 +1,7 @@
 #ifndef MOD_EVENT_KAFKA_H
 #define MOD_EVENT_KAFKA_H
 
-extern "C" { 
+extern "C" {
 	#include "librdkafka/rdkafka.h"
 }
 

--- a/mod_event_kafka.hpp
+++ b/mod_event_kafka.hpp
@@ -13,6 +13,7 @@ namespace mod_event_kafka {
 		char *username;
 		char *password;
 		int buffer_size;
+		int max_retry;
 	} globals;
 
 	SWITCH_MODULE_LOAD_FUNCTION(mod_event_kafka_load);


### PR DESCRIPTION
### [WIP]

- Added retry limit in config and reversed limit check on retry to allow for non-retry usage
- Killed off implicit int->bool conversion of initialized member
- Cleaned up rd_kafka_produce() result check slightly for better readability